### PR TITLE
Support explicit job-name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,24 @@ jobs:
           [[ "${{ env.SLACK_TITLE }}" == 'CI test succeeded' ]]
           [[ -n "${{ env.SLACK_MESSAGE }}" ]]
           [[ -n "${{ env.SLACK_FOOTER }}" ]]
+
+  test-matrix:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env:
+          - dev
+          - prod
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          slack-webhook-url: unused
+          job-name: "${{ github.job }} (${{ matrix.env }})"
+          dry-run: true
+      - run: |
+          [[ "${{ env.SLACK_COLOR }}" == 'success' ]]
+          [[ "${{ env.SLACK_TITLE }}" == 'CI test-matrix succeeded' ]]
+          [[ -n "${{ env.SLACK_MESSAGE }}" ]]
+          [[ -n "${{ env.SLACK_FOOTER }}" ]]

--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ Minimal inputs action to notify Slack of Job status
 
 ## Slack Users
 
+If told the mapping from GitHub Username to Slack User Id, this action will
+at-mention the author of the commit in which the Job is running:
+
 ```yaml
 - uses: freckle/slack-notify-action@v1
   with:

--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ Minimal inputs action to notify Slack of Job status
 ## Job Name
 
 In order to locate the URL to the Job in which we're running, we need to know
-the Job *Name*. Within the action, GitHub exposes `github.job`, which is the Job
-*Id*. These are usually the same, unless you've given an explicit `name` or are
+the Job _Name_. Within the action, GitHub exposes `github.job`, which is the Job
+_Id_. These are usually the same, unless you've given an explicit `name` or are
 running the Job in a matrix. If either of these are true, the action cannot
 determine the Job URL and will error. Unfortunately, GitHub does not offer any
 way for us to handle this, so you must provide the `job-name` input from the
@@ -139,10 +139,10 @@ You can do so literally:
 ```yaml
 name: "My Cool Job"
 steps:
- - uses: freckle/slack-notify-action@v1
-   with:
-     slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
-     job-name: "My Cool Job"
+  - uses: freckle/slack-notify-action@v1
+    with:
+      slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+      job-name: "My Cool Job"
 ```
 
 Or dynamically:
@@ -150,10 +150,10 @@ Or dynamically:
 ```yaml
 name: "My Cool Job"
 steps:
- - uses: freckle/slack-notify-action@v1
-   with:
-     slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
-     job-name: ${{ github.jobs[github.job].name }}
+  - uses: freckle/slack-notify-action@v1
+    with:
+      slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+      job-name: ${{ github.jobs[github.job].name }}
 ```
 
 And for matrices:
@@ -166,10 +166,10 @@ strategy:
       - prod
 
 steps:
- - uses: freckle/slack-notify-action@v1
-   with:
-     slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
-     job-name: ${{ github.job }} (${{ matrix.env }})
+  - uses: freckle/slack-notify-action@v1
+    with:
+      slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+      job-name: ${{ github.job }} (${{ matrix.env }})
 ```
 
 ## Slack Users

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,13 @@ inputs:
     required: false
     default: ""
 
+  job-name:
+    description: |
+      An explicit job-name, in cases where github.job (the job.id) won't work
+      such as matrix jobs.
+    required: false
+    default: ""
+
   github-token:
     description: ""
     required: false
@@ -170,11 +177,23 @@ runs:
     - shell: bash
       run: |
         # Set SLACK_FOOTER
-        gh --repo '${{ github.repository }}' run view '${{ github.run_id }}' \
-          --json jobs \
-          --jq '.jobs[] | select(.name == "${{ github.job }}") | "SLACK_FOOTER=" + .url' >>"$GITHUB_ENV"
+        url=$(
+          gh --repo '${{ github.repository }}' run view '${{ github.run_id }}' \
+            --json jobs \
+            --jq ".jobs[] | select(.name == \"$JOB_NAME\") | .url"
+        )
+
+        if [[ -z "$url" ]]; then
+          echo "No Job with name $JOB_NAME found in Workflow Runs:" >&2
+          gh --repo '${{ github.repository }}' run view '${{ github.run_id }}' \
+            --json jobs --jq '.jobs[] | .name' >&2
+          exit 1
+        fi
+
+        echo "SLACK_FOOTER=$url" >>"$GITHUB_ENV"
       env:
         GH_TOKEN: ${{ inputs.github-token }}
+        JOB_NAME: ${{ inputs.job-name || github.job }}
 
     - if: ${{ inputs.dry-run != 'true' }}
       name: Notify


### PR DESCRIPTION
GitHub only exposes `github.job` (the Job Id) or, if there was an
explicit name given, you can do `github.jobs[github.job].name`. There is
no way to get the complete Job Name given in the case of a matrix Job.

This means that, for example, we can't look up the Job URL for `deploy
(prod)` because we only know the `deploy` part.

The various actions that do this all accept an explicit name input, so
that you can pass it from the outside where you can include `${{
matrix.env }}` yourself -- so we support that here now.