### PR TITLE
Rewrite test in BATS, fix inputs.message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,26 @@ jobs:
         with:
           slack-webhook-url: unused
           dry-run: true
-      - run: |
-          [[ "${{ env.SLACK_COLOR }}" == 'success' ]]
-          [[ "${{ env.SLACK_TITLE }}" == 'CI test succeeded' ]]
-          [[ -n "${{ env.SLACK_MESSAGE }}" ]]
-          [[ -n "${{ env.SLACK_FOOTER }}" ]]
+
+      - uses: bats-core/bats-action@2.0.0
+        with:
+          support-path: /usr/lib/bats/bats-support
+          assert-path: /usr/lib/bats/bats-assert
+
+      - name: Setup
+        run: |
+          cat >test.bats <<'EOM'
+          bats_load_library bats-support
+          bats_load_library bats-assert
+
+          assert_equal "$SLACK_COLOR" 'success'
+          assert_equal "$SLACK_TITLE" 'CI test succeeded'
+          assert test -n "$SLACK_MESSAGE"
+          assert test -n "$SLACK_FOOTER"
+          EOM
+
+      - name: Test
+        run: bats test.bats
 
   test-matrix:
     runs-on: ubuntu-latest
@@ -35,8 +50,23 @@ jobs:
           slack-webhook-url: unused
           job-name: "${{ github.job }} (${{ matrix.env }})"
           dry-run: true
-      - run: |
-          [[ "${{ env.SLACK_COLOR }}" == 'success' ]]
-          [[ "${{ env.SLACK_TITLE }}" == 'CI test-matrix succeeded' ]]
-          [[ -n "${{ env.SLACK_MESSAGE }}" ]]
-          [[ -n "${{ env.SLACK_FOOTER }}" ]]
+
+      - uses: bats-core/bats-action@2.0.0
+        with:
+          support-path: /usr/lib/bats/bats-support
+          assert-path: /usr/lib/bats/bats-assert
+
+      - name: Setup
+        run: |
+          cat >test.bats <<'EOM'
+          bats_load_library bats-support
+          bats_load_library bats-assert
+
+          assert_equal "$SLACK_COLOR" 'success'
+          assert_equal "$SLACK_TITLE" 'CI test-matrix succeeded'
+          assert test -n "$SLACK_MESSAGE"
+          assert test -n "$SLACK_FOOTER"
+          EOM
+
+      - name: Test
+        run: bats test.bats

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
       - uses: ./
         with:
           slack-webhook-url: unused
+          message: |
+            Some extra message content
+            that is multi-line
           dry-run: true
 
       - uses: bats-core/bats-action@2.0.0
@@ -28,8 +31,12 @@ jobs:
 
           assert_equal "$SLACK_COLOR" 'success'
           assert_equal "$SLACK_TITLE" 'CI test succeeded'
-          assert test -n "$SLACK_MESSAGE"
           assert test -n "$SLACK_FOOTER"
+
+          run echo "$SLACK_MESSAGE"
+          assert_line --index 0 --regexp '^[^ ]* committed'
+          assert_line --index 1 'Some extra message content'
+          assert_line --index 2 'that is multi-line'
           EOM
 
       - name: Test

--- a/action.yml
+++ b/action.yml
@@ -166,13 +166,15 @@ runs:
             "$commit_sha_short" \
             "$commit_timestamp_r" \
             "$commit_timestamp"
-          cat # extra message on stdin
+          echo "$MESSAGE"
           echo "EOM"
         } >>"$GITHUB_ENV"
 
         if [[ "$author" == '<@unknown>' ]]; then
           cat "$GITHUB_ACTION_PATH/unknown.txt" >&2
         fi
+      env:
+        MESSAGE: ${{ inputs.message }}
 
     - shell: bash
       run: |


### PR DESCRIPTION
### [Rewrite test in BATS](https://github.com/freckle/slack-notify-action/pull/9/commits/ada250bbffe84823c6b99a5bc0f000cfc5e43329)
[ada250b](https://github.com/freckle/slack-notify-action/pull/9/commits/ada250bbffe84823c6b99a5bc0f000cfc5e43329)

The naive bash assertions are good verification and regression proofing
to start with, but upgrading to an actual test language means we can do
more advanced things (such as testing the `inputs.message` functionality
I'm about to fix) and get more useful information on failures. For
example, here's a failure I got in the process of working on
`inputs.message`:

![](https://files.pbrisbin.com/screenshots/screenshot.739258.png)

### [Implement inputs.message](https://github.com/freckle/slack-notify-action/pull/9/commits/f4966b1f6258fc7a4188a1c876c061a9f2812087)
[f4966b1](https://github.com/freckle/slack-notify-action/pull/9/commits/f4966b1f6258fc7a4188a1c876c061a9f2812087)

Fixes https://github.com/freckle/slack-notify-action/issues/8.