### PR TITLE
Include the unknown author in the message body

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -158,6 +158,11 @@ runs:
           author="$commit_author"
         fi
 
+        if [[ "$author" == '<@unknown>' ]]; then
+          cat "$GITHUB_ACTION_PATH/unknown.txt" >&2
+          author="$author ($commit_author)"
+        fi
+
         {
           echo "SLACK_MESSAGE<<EOM"
           printf '%s committed <%s|%s> %s (%s)\n' \
@@ -169,10 +174,6 @@ runs:
           echo "$MESSAGE"
           echo "EOM"
         } >>"$GITHUB_ENV"
-
-        if [[ "$author" == '<@unknown>' ]]; then
-          cat "$GITHUB_ACTION_PATH/unknown.txt" >&2
-        fi
       env:
         MESSAGE: ${{ inputs.message }}
 


### PR DESCRIPTION
Originally, we assumed that seeing a user avatar in the notification,
but an `<@unknown>` in the message body would directly indicate that
that's the user that needs to be added to the slack-users json.

However, there are circumstances where that's not the case. Notably,
where the PR author or workflow actor isn't the same person that made
the commit. This has led to some cases where _PR_ authors were asked to
address issues in the slack-users json when there were none. It was just
that the _commit_ author was a bot.

Showing the commit author in the message will prevent this confusion.
